### PR TITLE
Design flaw

### DIFF
--- a/www/assets/js/main_out.js
+++ b/www/assets/js/main_out.js
@@ -261,8 +261,8 @@
                     id = reader.getUint32();
                     if (0 === id) break;
 
-                    x = reader.getInt32();
-                    y = reader.getInt32();
+                    x = reader.getUint32();
+                    y = reader.getUint32();
                     size = reader.getUint16();
 
                     flags = reader.getUint8();


### PR DESCRIPTION
The client is trying to get a signed integer from the server, but since MultiOgar-Edited and the majority of all other Ogar based servers sends an unsigned integer to the client, this will result in a design flaw.

In other words, you cannot send an unsigned integer from the server and expect client to get a signed integer instead.

This PR fixes the "RangeError: Offset is out of bounds" error.