### PR TITLE
Remove unnecessary inline styling

### DIFF
--- a/www/assets/css/index.css
+++ b/www/assets/css/index.css
@@ -109,6 +109,7 @@ body {
 }
 
 #spectate-btn {
+    width: 100%
     margin-top: -5px;
 }
 

--- a/www/index.html
+++ b/www/index.html
@@ -70,7 +70,7 @@
 
                 <div id="settings" class="checkbox" style="display:none;">
                     <div class="form-group" id="mainform">
-                        <button id="spectate-btn" onclick="spectate(); return false;" style="width: 100%" class="btn btn-warning btn-spectate btn-needs-server">Spectate
+                        <button id="spectate-btn" onclick="spectate(); return false;" class="btn btn-warning btn-spectate btn-needs-server">Spectate
                         </button>
                         <br clear="both" />
                     </div>


### PR DESCRIPTION
This PR remove unnecessary inline styling from the spectate button, why not just use the css file when it is avaliable